### PR TITLE
use newer expand-tilde without os-homedir

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "expand-tilde": "^1.2.2",
+    "expand-tilde": "^2.0.0",
     "global-modules": "^0.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
os-homedir uses hardcoded paths which is not guaranteed to work reliably. exapnd-tilde 2.0.0 does not depend on os-homedir

Closes: #2 
